### PR TITLE
chore: add pre-commit and semantic-release automation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    concurrency:
+      group: release
+      cancel-in-progress: false
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@master
+      with:
+        fetch-depth: 0
+
+    - name: Semantic Version Release
+      uses: python-semantic-release/python-semantic-release@v10.6.1
+      with:
+        github_token: ${{ secrets.RELEASE_TOKEN }}
+        git_committer_name: "github-actions[bot]"
+        git_committer_email: "github-actions[bot]@users.noreply.github.com"
+
+    - name: Set up Python
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.12'
+
+    - name: Install uv
+      run: pip install uv
+
+    - name: Sync uv.lock version
+      env:
+        GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+      run: |
+        uv lock --upgrade-package celery-signal-receivers
+        if git diff --quiet -- uv.lock; then
+          echo "uv.lock already in sync"
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add uv.lock
+        git commit -m "chore: sync uv.lock version"
+        git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+default_install_hook_types: [pre-commit, commit-msg]
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.22
+    hooks:
+      - id: ruff-check
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - Django>=5.2,<7.0
+          - django-stubs>=5.2,<7.0
+          - pytest-django>=4.12.0,<5
+        args: [tests, src/celery_signals]
+        pass_filenames: false
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,3 +84,17 @@ ignore_missing_imports = true
 
 [tool.django-stubs]
 django_settings_module = "tests.testapp.settings"
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+tag_format = "{version}"
+major_on_zero = false
+allow_zero_version = true
+build_command = ""
+commit_message = "chore(release): {version}"
+
+[tool.semantic_release.branches.main]
+match = "master"
+
+[tool.semantic_release.remote]
+type = "github"


### PR DESCRIPTION
## Summary
- Add `.pre-commit-config.yaml` (ruff-check/ruff-format, mypy, conventional-pre-commit)
- Add `[tool.semantic_release]` config to `pyproject.toml` (pre-1.0, `major_on_zero = false` + `allow_zero_version = true`)
- Add `.github/workflows/release.yaml` (manual-dispatch semantic release + uv.lock sync)