### PR TITLE
chore: add PyPI/TestPyPI publish workflows + README updates

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,0 +1,69 @@
+name: Publish to PyPI
+
+#checkov:skip=CKV_GHA_7:tag input is validated against existing GitHub releases via `gh release view` before checkout, cannot reference arbitrary refs
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (defaults to latest release if omitted)'
+        required: false
+        type: string
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Resolve release tag
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG_INPUT: ${{ inputs.tag }}
+      run: |
+        if [ -n "$TAG_INPUT" ]; then
+          tag="$TAG_INPUT"
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
+        else
+          tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+        fi
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+    - uses: actions/checkout@master
+      with:
+        ref: ${{ steps.release.outputs.tag }}
+    - name: Set up Python
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.12'
+    - name: Install uv
+      run: pip install uv
+    - name: Build distributions
+      run: uv build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: dist
+        path: dist/
+
+  publish-pypi:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/celery-signal-receivers
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@master
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-testpypi.yaml
+++ b/.github/workflows/publish-testpypi.yaml
@@ -1,0 +1,71 @@
+name: Publish to TestPyPI
+
+#checkov:skip=CKV_GHA_7:tag input is validated against existing GitHub releases via `gh release view` before checkout, cannot reference arbitrary refs
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (defaults to latest release if omitted)'
+        required: false
+        type: string
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - name: Resolve release tag
+      id: release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        TAG_INPUT: ${{ inputs.tag }}
+      run: |
+        if [ -n "$TAG_INPUT" ]; then
+          tag="$TAG_INPUT"
+          gh release view "$tag" --repo "${{ github.repository }}" >/dev/null
+        else
+          tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+        fi
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+    - uses: actions/checkout@master
+      with:
+        ref: ${{ steps.release.outputs.tag }}
+    - name: Set up Python
+      uses: actions/setup-python@master
+      with:
+        python-version: '3.12'
+    - name: Install uv
+      run: pip install uv
+    - name: Build distributions
+      run: uv build
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: dist
+        path: dist/
+
+  publish-testpypi:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/celery-signal-receivers
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@master
+      with:
+        name: dist
+        path: dist/
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Celery Signal Receivers
 
+[![Continuous Integration](https://github.com/ivellios/celery-signal-receivers/actions/workflows/ci.yaml/badge.svg)](https://github.com/ivellios/celery-signal-receivers/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/ivellios/celery-signal-receivers/branch/master/graph/badge.svg)](https://codecov.io/gh/ivellios/celery-signal-receivers)
+
 Make Django signals asynchronous with Celery tasks. This package allows you to convert and write signal receivers to run in the background as Celery tasks.
 
 # Installation
@@ -89,3 +92,18 @@ def foo(sender, message: ProfileMessage, **kwargs):
 For now this package does not support multiple signals passed to the `@receiver_task` decorator. 
 You should create separate receivers for each signal.
 This may be added in the future. 
+
+# Contributing
+
+Commits must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.) —
+enforced locally via `pre-commit install` (installs both the `pre-commit` and `commit-msg` hooks).
+They drive automated version bumps and changelog generation via
+[python-semantic-release](https://python-semantic-release.readthedocs.io/).
+
+# Releasing
+
+Run the `Release` workflow manually from the Actions tab (targets `master`) whenever the changes
+on `master` are ready to ship. It computes the next version from commit history, bumps
+`pyproject.toml`, updates `CHANGELOG.md`, tags the commit, and publishes a GitHub Release.
+Publishing to PyPI is still done manually.
+


### PR DESCRIPTION
## Summary
- Add `publish-pypi.yaml` / `publish-testpypi.yaml` (workflow_dispatch, OIDC trusted publishing, copied from django-unified-signals reference)
- Add CI + codecov badges and Contributing/Releasing sections to README

## Notes
- Codecov CI upload step already landed in PR 1 (`ci.yaml`); this PR only adds the README badge, not the mechanism
- Not yet done (external, left to repo owner): GitHub `pypi`/`testpypi` environments, PyPI/TestPyPI trusted-publisher config, Codecov signup + `CODECOV_TOKEN` secret