### PR TITLE
feat: upload coverage report to Codecov in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,12 @@ jobs:
       run: pip install tox uv
     - name: Run check
       run: tox -e ${{ matrix.check }}
+    - name: Upload coverage to Codecov
+      if: matrix.check == 'coverage'
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
 
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add missing Codecov upload step to `ci.yaml`'s coverage check job (copied from django-unified-signals reference)

## Notes
- Uploads will no-op/fail until the `CODECOV_TOKEN` repo secret is added (Codecov signup still pending, external step)