### PR TITLE
fix: validate receiver_task input and detect Celery task name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ class ProfileMessage:
     name: str
 ```
 
+The message is serialized to JSON before being handed to the Celery task, so every field on the
+message class must be JSON-serializable via the standard library `json` module - plain
+dataclasses of `str`/`int`/`float`/`bool`/`None`/lists/dicts work, but `datetime`, `Decimal`,
+`UUID`, etc. don't and will raise a `TypeError` when the signal is sent. Convert such fields to a
+JSON-friendly representation (e.g. `datetime.isoformat()`) before constructing the message.
+Stick to plain `@dataclasses.dataclass` message classes - classes with `__slots__` or a custom
+`__init__` that doesn't mirror `__dict__` aren't supported.
+
 Now that we have the message structure defined, we can create the signal. We will use `UnifiedSignal` class for that:
 
 ```python
@@ -89,9 +97,15 @@ def foo(sender, message: ProfileMessage, **kwargs):
 
 # Limitations
 
-For now this package does not support multiple signals passed to the `@receiver_task` decorator. 
-You should create separate receivers for each signal.
-This may be added in the future. 
+For now this package does not support multiple signals passed to the `@receiver_task` decorator
+(passing a list/tuple raises a `TypeError`). You should create separate receivers for each signal.
+This may be added in the future.
+
+Celery names tasks after the decorated function's module and name. If you generate receivers
+dynamically (e.g. in a loop or factory helper) and two of them end up with the same function name
+in the same module, `receiver_task` raises `ImproperlyConfigured` rather than silently letting one
+receiver's task overwrite the other's - pass an explicit unique `name` via `celery_task_options` to
+disambiguate in that case.
 
 # Contributing
 

--- a/src/celery_signals/receivers.py
+++ b/src/celery_signals/receivers.py
@@ -40,6 +40,13 @@ def receiver_task(
     if celery_task_options is None:
         celery_task_options = {}
 
+    if not isinstance(signal, UnifiedSignal):
+        raise TypeError(
+            "receiver_task() requires a single UnifiedSignal instance, not "
+            f"{signal!r}. Multiple signals are not supported - create a "
+            "separate receiver for each signal."
+        )
+
     def decorator(func):
         @wraps(func)
         def consumer_function(message_data: str = "{}", *args, **kwargs):
@@ -47,6 +54,14 @@ def receiver_task(
             return func(*args, sender=None, message=message, **kwargs)
 
         consumer = app.task(**celery_task_options)(consumer_function)
+        if consumer.run is not consumer_function:
+            raise ImproperlyConfigured(
+                f"Celery task name {consumer.name!r} is already registered to "
+                "a different receiver. This happens when two receiver_task-"
+                "decorated functions share the same __name__ in the same "
+                "module (e.g. generated via a factory/loop pattern). Pass an "
+                "explicit unique `name` via celery_task_options to disambiguate."
+            )
         app.register_task(consumer)
 
         def producer(

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -1,4 +1,5 @@
 import dataclasses
+import datetime
 from unittest import mock
 
 import pytest
@@ -221,6 +222,27 @@ def test_receiver_task_rejects_list_of_signals():
 
         @receiver_task([signal], weak=False)
         def handle_signal_list(**kwargs): ...
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    EVENT_SIGNALS_CELERY_APP="tests.testapp.celery.app",
+)
+def test_signal_send_raises_on_non_json_serializable_message_field():
+    @dataclasses.dataclass
+    class TimestampedMessage:
+        created_at: datetime.datetime
+
+    signal = UnifiedSignal(TimestampedMessage)
+
+    @receiver_task(signal, weak=False)
+    def handle_signal_timestamp(**kwargs): ...
+
+    with pytest.raises(TypeError):
+        signal.send(
+            SenderMock(), TimestampedMessage(created_at=datetime.datetime.now())
+        )
 
 
 def test_registered_task_raises_on_malformed_message_payload():

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -112,15 +112,20 @@ def test_celery_signal_receiver_dispatch_uid_prevents_duplicate_registration():
     signal = UnifiedSignal(DataMock)
     calls = []
 
-    def make_receiver():
-        @receiver_task(signal, dispatch_uid="handle_signal_dispatch_uid", weak=False)
-        def handle_signal_dispatch_uid(sender, message, **kwargs):
+    def make_receiver(name):
+        @receiver_task(
+            signal,
+            dispatch_uid="handle_signal_dispatch_uid",
+            celery_task_options={"name": f"tests.test_receivers.{name}"},
+            weak=False,
+        )
+        def handler(sender, message, **kwargs):
             calls.append(message)
 
-        return handle_signal_dispatch_uid
+        return handler
 
-    make_receiver()
-    make_receiver()
+    make_receiver("dispatch_uid_receiver_a")
+    make_receiver("dispatch_uid_receiver_b")
 
     signal.send(SenderMock(), DataMock(field=10))
 
@@ -136,15 +141,19 @@ def test_celery_signal_receiver_without_dispatch_uid_allows_duplicate_registrati
     signal = UnifiedSignal(DataMock)
     calls = []
 
-    def make_receiver():
-        @receiver_task(signal, weak=False)
-        def handle_signal_no_dispatch_uid(sender, message, **kwargs):
+    def make_receiver(name):
+        @receiver_task(
+            signal,
+            celery_task_options={"name": f"tests.test_receivers.{name}"},
+            weak=False,
+        )
+        def handler(sender, message, **kwargs):
             calls.append(message)
 
-        return handle_signal_no_dispatch_uid
+        return handler
 
-    make_receiver()
-    make_receiver()
+    make_receiver("no_dispatch_uid_receiver_a")
+    make_receiver("no_dispatch_uid_receiver_b")
 
     signal.send(SenderMock(), DataMock(field=10))
 
@@ -185,6 +194,33 @@ def test_celery_signal_receiver_threads_extra_kwargs_to_handler():
     signal.send(SenderMock(), DataMock(field=10), extra="value")
 
     assert received_kwargs[0].get("extra") == "value"
+
+
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    EVENT_SIGNALS_CELERY_APP="tests.testapp.celery.app",
+)
+def test_receiver_task_raises_on_celery_task_name_collision():
+    signal_a = UnifiedSignal(DataMock)
+    signal_b = UnifiedSignal(DataMock)
+
+    @receiver_task(signal_a, weak=False)
+    def handle_signal_collision(**kwargs): ...
+
+    with pytest.raises(ImproperlyConfigured):
+
+        @receiver_task(signal_b, weak=False)
+        def handle_signal_collision(**kwargs): ...  # noqa: F811
+
+
+def test_receiver_task_rejects_list_of_signals():
+    signal = UnifiedSignal(DataMock)
+
+    with pytest.raises(TypeError):
+
+        @receiver_task([signal], weak=False)
+        def handle_signal_list(**kwargs): ...
 
 
 def test_registered_task_raises_on_malformed_message_payload():


### PR DESCRIPTION
## Summary
- **Bug fix**: Celery names tasks by `(module, function.__name__)` and silently reuses the first-ever registered task under a colliding name, discarding the second receiver's task with no error — if two receivers happen to share a function name (e.g. via a factory/loop pattern), the second receiver's signal silently invokes the first receiver's task body instead. Now raises `ImproperlyConfigured` instead of allowing this silent corruption.
- **Bug fix**: `receiver_task` now rejects non-`UnifiedSignal` input (e.g. a list of signals) with a clear `TypeError` raised before any Celery task is registered, instead of leaving a zombie task registered and then crashing with a confusing raw `AttributeError`.
- Rewrote the two dispatch_uid duplicate-registration tests, which had unknowingly relied on the same collision bug to demonstrate Django-level receiver dedup.
- Added a test locking in that non-JSON-serializable message fields (e.g. `datetime`) raise synchronously in `signal.send()`, before any task is queued.
- Documented the JSON-serialization requirement for message classes and the task-name collision gotcha (with the `celery_task_options={"name": ...}` workaround) in the README.