### PR TITLE
fix: Python 3.14 compat, drop redundant task registration, doc/fixture cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
         django-version: ["5.2", "6.0"]
         exclude:
           - python-version: "3.11"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ profile_updated_signal = UnifiedSignal(ProfileMessage)
 See the [documentation of Django Unified Signals](https://pypi.org/project/django-unified-signals/) to learn more about sending the signal
 with standardized message.
 
-Let's now write receiver for the signal. We will use the `celery_signal_receivers.receiver` decorator to convert the receiver to Celery task.
+Let's now write receiver for the signal. We will use the `celery_signals.receiver_task` decorator to convert the receiver to Celery task.
 
 ```python
 from celery_signals import receiver_task
@@ -106,6 +106,11 @@ dynamically (e.g. in a loop or factory helper) and two of them end up with the s
 in the same module, `receiver_task` raises `ImproperlyConfigured` rather than silently letting one
 receiver's task overwrite the other's - pass an explicit unique `name` via `celery_task_options` to
 disambiguate in that case.
+
+`receiver_task` returns the original, undecorated function unchanged. Calling it directly (e.g.
+`handle_profile_updated(sender, message=...)`) runs it synchronously and skips Celery entirely, so
+only `signal.send(...)` (or invoking the registered Celery task directly) goes through the async,
+JSON-round-tripped path.
 
 # Contributing
 

--- a/src/celery_signals/receivers.py
+++ b/src/celery_signals/receivers.py
@@ -1,7 +1,6 @@
 import importlib
 import json
 import typing
-from functools import wraps
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -48,10 +47,14 @@ def receiver_task(
         )
 
     def decorator(func):
-        @wraps(func)
-        def consumer_function(message_data: str = "{}", *args, **kwargs):
+        def consumer_function(message_data: str = "{}", **kwargs):
             message = signal.message_class(**json.loads(message_data))
-            return func(*args, sender=None, message=message, **kwargs)
+            return func(sender=None, message=message, **kwargs)
+
+        consumer_function.__name__ = func.__name__
+        consumer_function.__module__ = func.__module__
+        consumer_function.__qualname__ = func.__qualname__
+        consumer_function.__doc__ = func.__doc__
 
         consumer = app.task(**celery_task_options)(consumer_function)
         if consumer.run is not consumer_function:
@@ -62,17 +65,15 @@ def receiver_task(
                 "module (e.g. generated via a factory/loop pattern). Pass an "
                 "explicit unique `name` via celery_task_options to disambiguate."
             )
-        app.register_task(consumer)
 
         def producer(
             signal=signal,
             sender=None,
             message: typing.Any | None = None,
-            *_args,
             **_kwargs,
         ):
             message_data = json.dumps(message.__dict__) if message else "{}"
-            return consumer.delay(message_data, *_args, **_kwargs)
+            return consumer.delay(message_data, **_kwargs)
 
         options.setdefault("weak", False)
         signal.connect(producer, **options)

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -1,6 +1,5 @@
 import dataclasses
 import datetime
-from unittest import mock
 
 import pytest
 from django.conf import settings
@@ -8,7 +7,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
 from unified_signals import UnifiedSignal
 
-from celery_signals.receivers import get_celery_app, receiver_task
+from celery_signals.receivers import app, get_celery_app, receiver_task
 
 
 @dataclasses.dataclass
@@ -42,13 +41,13 @@ def test_celery_signal_receiver():
 def test_celery_signal_receiver_creates_celery_task():
     signal = UnifiedSignal(DataMock)
 
-    with mock.patch("tests.testapp.celery.app.register_task") as task_mock:
+    @receiver_task(signal, weak=False)
+    def handle_signal_creates_task(**kwargs): ...
 
-        @receiver_task(signal, weak=False)
-        def handle_signal_creates_task(**kwargs): ...
+    task_name = f"{handle_signal_creates_task.__module__}.handle_signal_creates_task"
+    assert task_name in app.tasks
 
-        signal.send(SenderMock(), DataMock(field=10))
-        task_mock.assert_called_once()
+    signal.send(SenderMock(), DataMock(field=10))
 
 
 @override_settings(
@@ -93,15 +92,16 @@ def test_celery_signal_receiver_fires_without_explicit_weak_option():
 def test_celery_signal_receiver_applies_celery_task_options():
     signal = UnifiedSignal(DataMock)
 
-    with mock.patch("tests.testapp.celery.app.register_task") as task_mock:
+    @receiver_task(
+        signal, celery_task_options={"queue": "profile-updated-queue"}, weak=False
+    )
+    def handle_signal_with_task_options(**kwargs): ...
 
-        @receiver_task(
-            signal, celery_task_options={"queue": "profile-updated-queue"}, weak=False
-        )
-        def handle_signal_with_task_options(**kwargs): ...
-
-        registered_task = task_mock.call_args.args[0]
-        assert registered_task.queue == "profile-updated-queue"
+    task_name = (
+        f"{handle_signal_with_task_options.__module__}.handle_signal_with_task_options"
+    )
+    registered_task = app.tasks[task_name]
+    assert registered_task.queue == "profile-updated-queue"
 
 
 @override_settings(
@@ -248,12 +248,13 @@ def test_signal_send_raises_on_non_json_serializable_message_field():
 def test_registered_task_raises_on_malformed_message_payload():
     signal = UnifiedSignal(DataMock)
 
-    with mock.patch("tests.testapp.celery.app.register_task") as task_mock:
+    @receiver_task(signal, weak=False)
+    def handle_signal_malformed_payload(**kwargs): ...
 
-        @receiver_task(signal, weak=False)
-        def handle_signal_malformed_payload(**kwargs): ...
-
-        registered_task = task_mock.call_args.args[0]
+    task_name = (
+        f"{handle_signal_malformed_payload.__module__}.handle_signal_malformed_payload"
+    )
+    registered_task = app.tasks[task_name]
 
     with pytest.raises(TypeError):
         registered_task('{"unexpected_field": 1}')

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -50,6 +50,26 @@ def test_celery_signal_receiver_creates_celery_task():
     signal.send(SenderMock(), DataMock(field=10))
 
 
+def test_registered_task_run_does_not_leak_receiver_signature():
+    signal = UnifiedSignal(DataMock)
+
+    @receiver_task(signal, weak=False)
+    def handle_signal_no_wrapped_leak(sender, message, **kwargs): ...
+
+    task_name = (
+        f"{handle_signal_no_wrapped_leak.__module__}.handle_signal_no_wrapped_leak"
+    )
+    registered_task = app.tasks[task_name]
+
+    # If consumer_function were wrapped via functools.wraps(func), it would carry
+    # __wrapped__, and Celery's own argument-checking follows __wrapped__ via
+    # inspect.signature() on Python 3.14+, validating calls against the receiver's
+    # signature (sender, message, **kwargs) instead of the task's real one
+    # (message_data="{}", **kwargs) - breaking every call. Guard against that
+    # regardless of which Python version runs this test.
+    assert not hasattr(registered_task.run, "__wrapped__")
+
+
 @override_settings(
     CELERY_TASK_ALWAYS_EAGER=True,
     CELERY_TASK_EAGER_PROPAGATES=True,

--- a/tests/testapp/celery.py
+++ b/tests/testapp/celery.py
@@ -4,7 +4,7 @@ import os
 from celery import Celery
 
 # Set the default Django settings module for the 'celery' program.
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.testapp.settings")
 
 app = Celery("project")
 

--- a/tests/testapp/settings.py
+++ b/tests/testapp/settings.py
@@ -2,6 +2,4 @@
 
 SECRET_KEY = "Some secret key"
 
-# CELERY_ALWAYS_EAGER = True
-
 EVENT_SIGNALS_CELERY_APP = "tests.testapp.celery.app"

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     liccheck
     mypy
     coverage
-    py{3.11,3.12,3.13}-dj{5.2,6.0}
+    py{3.11,3.12,3.13,3.14}-dj{5.2,6.0}
 
 [testenv]
 allowlist_externals = uv


### PR DESCRIPTION
## Summary
- Bug fix: receiver functions were wrapped via functools.wraps(func), which sets __wrapped__. On Python 3.14, Celery's own argument checker follows __wrapped__ via inspect.signature() and validates calls against the receiver's signature instead of the task's real one, raising TypeError on every call. Fixed by copying the needed attributes manually instead of using wraps, and added a version-independent test that locks this in.
- Removed the now-redundant app.register_task(consumer) call, app.task() already registers the task.
- Removed unreachable *args/*_args passthrough in producer/consumer_function, UnifiedSignal.send and Django's dispatcher only ever pass keyword arguments.
- Added Python 3.14 to the CI and tox test matrix, matching what pyproject.toml already claims to support.
- Fixed a README typo (wrong decorator import path) and documented that calling a receiver_task-decorated function directly bypasses Celery entirely.
- Cleaned up stale test-fixture leftovers (dead DJANGO_SETTINGS_MODULE default, dead commented-out setting).