### PR TITLE
fix: producer's falsy-message check silently drops real message data

### DIFF
--- a/src/celery_signals/receivers.py
+++ b/src/celery_signals/receivers.py
@@ -72,7 +72,7 @@ def receiver_task(
             message: typing.Any | None = None,
             **_kwargs,
         ):
-            message_data = json.dumps(message.__dict__) if message else "{}"
+            message_data = json.dumps(message.__dict__) if message is not None else "{}"
             return consumer.delay(message_data, **_kwargs)
 
         options.setdefault("weak", False)

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -265,6 +265,31 @@ def test_signal_send_raises_on_non_json_serializable_message_field():
         )
 
 
+@override_settings(
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=True,
+    EVENT_SIGNALS_CELERY_APP="tests.testapp.celery.app",
+)
+def test_celery_signal_receiver_delivers_falsy_message():
+    @dataclasses.dataclass
+    class FalsyMessage:
+        items: list
+
+        def __bool__(self):
+            return bool(self.items)
+
+    signal = UnifiedSignal(FalsyMessage)
+    received = []
+
+    @receiver_task(signal, weak=False)
+    def handle_signal_falsy_message(sender, message, **kwargs):
+        received.append(message)
+
+    signal.send(SenderMock(), FalsyMessage(items=[]))
+
+    assert received == [FalsyMessage(items=[])]
+
+
 def test_registered_task_raises_on_malformed_message_payload():
     signal = UnifiedSignal(DataMock)
 

--- a/tests/test_receivers.py
+++ b/tests/test_receivers.py
@@ -1,5 +1,6 @@
 import dataclasses
 import datetime
+import json
 
 import pytest
 from django.conf import settings
@@ -303,6 +304,21 @@ def test_registered_task_raises_on_malformed_message_payload():
 
     with pytest.raises(TypeError):
         registered_task('{"unexpected_field": 1}')
+
+
+def test_registered_task_raises_on_non_json_message_payload():
+    signal = UnifiedSignal(DataMock)
+
+    @receiver_task(signal, weak=False)
+    def handle_signal_non_json_payload(**kwargs): ...
+
+    task_name = (
+        f"{handle_signal_non_json_payload.__module__}.handle_signal_non_json_payload"
+    )
+    registered_task = app.tasks[task_name]
+
+    with pytest.raises(json.JSONDecodeError):
+        registered_task("not json")
 
 
 def test_receivers_import_without_celery_app_defined():


### PR DESCRIPTION
## Summary
- Bug fix: producer used `if message else "{}"` to decide whether to serialize the message. A message dataclass that defines `__bool__`/`__len__` (e.g. wraps a collection that can be empty) would make a real, non-None message instance falsy, silently substituting an empty payload and losing the actual message data on the async path. Changed to an explicit `is not None` check.
- Added a regression test with a message class overriding `__bool__`, confirming the real field value round-trips instead of getting replaced with an empty-dict-constructed message. Verified it fails against the old code before the fix.
- Added a test covering a genuinely malformed (non-JSON) message payload, asserting `json.JSONDecodeError` is raised, distinct from the existing test that covers valid JSON with an unexpected field (`TypeError`).